### PR TITLE
Fixed day collection to comply with API functionality

### DIFF
--- a/data-collectors/environment-appa/appatn_tenminutes/src/main/java/info/datatellers/appatn/tenminutes/JobScheduler.java
+++ b/data-collectors/environment-appa/appatn_tenminutes/src/main/java/info/datatellers/appatn/tenminutes/JobScheduler.java
@@ -28,7 +28,7 @@ import it.bz.idm.bdp.dto.StationList;
 @Component("jobScheduler")
 public class JobScheduler {
 
-	private static final Logger LOG = LogManager.getLogger(Tester.class.getName());
+	private static final Logger LOG = LogManager.getLogger(JobScheduler.class.getName());
 
 	public void collectData() {
 		try {


### PR DESCRIPTION
Issue #57 is fixed.

The issue originated from the fact that the API has some strange way to define date bounds, excluding the day selected. So even if, for example, from-date=25-01-2019 and to-date=25-01-2019, the data returned will be of 24-01-2019.

New fixes should be able to take care of data pushing even if and when the API will be pushing new data every 10 minutes, although there is no real way to test and prove that as of today.

Awaiting feedback from your side!